### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyrogram==1.0.1
 tgcrypto
 oauth2client
 psycopg2-binary
-sqlalchemy
+sqlalchemy==1.3.23
 httplib2
 pySmartDL
 google-api-python-client


### PR DESCRIPTION
sqlalchemy v1.4.0 was causing errors so rolled back to old version of sqlalchemy now no heroku deployment error